### PR TITLE
implemented caching for withdrawals

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Update contract addresses in `config.js`
 $ ./cli.js sacredtest eth 0.1 <RECIPIENT ADDR> --rpc <RPC URL>
 ```
 
+### Cache
+
+Cache Events
+```bash
+$ node ./cli.js cache <EVENT_TYPE> <NET_ID> <CURRENCY> <AMOUNT> --rpc <RPC URL>
+```
+
 ## Contract guidance
 
 TBA.


### PR DESCRIPTION
Everytime user tries to withdraw using cli, events will be cached, 

Also, Events can be cached manually using cli, 

`node ./cli.js cache Deposit 42 eth 0.1 --rpc https://eth-kovan.alchemyapi.io/v2/YAQqwvDfZbKykKxK9RdXaUPoO3a2XEVG`